### PR TITLE
fix(ci): add missing pull-requests permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
 permissions:
   id-token: write
   contents: write
+  pull-requests: read # required to satisfy static permission check for paths-filter
 
 concurrency:
   group: release-production


### PR DESCRIPTION
The paths filter job requires PR read permissions to work. Even though the release script itself does not need it, apparently Github Actions still statically checks permissions independently of their actual use.